### PR TITLE
add ability to reset targets per task or for the whole manifest

### DIFF
--- a/dnit.ts
+++ b/dnit.ts
@@ -305,9 +305,9 @@ export class Task {
 
   private async cleanTargets(ctx: ExecContext): Promise<void> {
     await Promise.all(
-        Array.from(this.targets).map((tf) => {
+        Array.from(this.targets).map(async (tf) => {
           try {
-            ctx.asyncQueue.schedule(() => tf.delete())
+            await ctx.asyncQueue.schedule(() => tf.delete())
           } catch (err) {
             ctx.taskLogger.error(`Error scheduling deletion of ${tf.path}`, err);
           }

--- a/dnit.ts
+++ b/dnit.ts
@@ -54,6 +54,7 @@ export interface TaskContext {
   logger: log.Logger;
   task: Task;
   args: flags.Args;
+  exec: ExecContext;
 }
 
 function taskContext(ctx: ExecContext, task: Task): TaskContext {
@@ -61,6 +62,7 @@ function taskContext(ctx: ExecContext, task: Task): TaskContext {
     logger: ctx.taskLogger,
     task,
     args: ctx.args,
+    exec: ctx
   };
 }
 

--- a/dnit.ts
+++ b/dnit.ts
@@ -769,6 +769,10 @@ export async function execBasic(
   const args = flags.parse(cliArgs);
   const ctx = new ExecContext(manifest, args);
   tasks.forEach((t) => ctx.taskRegister.set(t.name, t));
+
+  /// register built-in tasks:
+  ctx.taskRegister.set(clean.name, clean);
+
   await Promise.all(
     Array.from(ctx.taskRegister.values()).map((t) =>
       ctx.asyncQueue.schedule(() => t.setup(ctx))

--- a/dnit/main.ts
+++ b/dnit/main.ts
@@ -1,5 +1,5 @@
 import { flags, log, semver, task, utils } from "./deps.ts";
-import { main, file, runAlways, TaskContext } from "../dnit.ts";
+import { main, file, runAlways, TaskContext, trackFile } from "../dnit.ts";
 
 import {
   fetchTags,
@@ -251,7 +251,33 @@ const killTest = task({
   uptodate: runAlways,
 });
 
+const exampleTarget1 = trackFile({
+  path: 'exampleTarget1.txt',
+});
+const testTarget1 = task({
+  name: 'exampleGen1',
+  description: 'Test task to generate (and allow clean) of an example target',
+  action: async () => {
+    await Deno.writeTextFile(exampleTarget1.path, 'example contents');
+  },
+  targets: [exampleTarget1],
+});
+
+const exampleTarget2 = trackFile({
+  path: 'exampleTarget2.txt',
+});
+const testTarget2 = task({
+  name: 'exampleGen2',
+  description: 'Test task to generate (and allow clean) of an example target',
+  action: async () => {
+    await Deno.writeTextFile(exampleTarget1.path, 'example contents');
+  },
+  targets: [exampleTarget2],
+});
+
 const tasks = [
+  testTarget1,
+  testTarget2,
   test,
   genadl,
   tag,

--- a/dnit/main.ts
+++ b/dnit/main.ts
@@ -1,5 +1,5 @@
 import { flags, log, semver, task, utils } from "./deps.ts";
-import { main, file, runAlways, TaskContext, trackFile } from "../dnit.ts";
+import { main, file, runAlways, TaskContext } from "../dnit.ts";
 
 import {
   fetchTags,

--- a/dnit/main.ts
+++ b/dnit/main.ts
@@ -251,33 +251,7 @@ const killTest = task({
   uptodate: runAlways,
 });
 
-const exampleTarget1 = trackFile({
-  path: 'exampleTarget1.txt',
-});
-const testTarget1 = task({
-  name: 'exampleGen1',
-  description: 'Test task to generate (and allow clean) of an example target',
-  action: async () => {
-    await Deno.writeTextFile(exampleTarget1.path, 'example contents');
-  },
-  targets: [exampleTarget1],
-});
-
-const exampleTarget2 = trackFile({
-  path: 'exampleTarget2.txt',
-});
-const testTarget2 = task({
-  name: 'exampleGen2',
-  description: 'Test task to generate (and allow clean) of an example target',
-  action: async () => {
-    await Deno.writeTextFile(exampleTarget1.path, 'example contents');
-  },
-  targets: [exampleTarget2],
-});
-
 const tasks = [
-  testTarget1,
-  testTarget2,
   test,
   genadl,
   tag,

--- a/dnit/main.ts
+++ b/dnit/main.ts
@@ -180,9 +180,6 @@ const genadl = task({
       ["git", "apply", "./tools/0001-Revert-non-desired-gen-adl-edits.patch"],
     );
   },
-  targets: [
-    file({ path: "./adl-gen/dnit/manifest.ts" }),
-  ],
   deps: [
     file({ path: "./adl/manifest.adl" }),
     file({ path: "./tools/0001-Revert-non-desired-gen-adl-edits.patch" }),

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -4,11 +4,13 @@ import {
   runAlways,
   task,
   TrackedFile,
+  trackFile,
 } from "../dnit.ts";
 
 import { assertEquals } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 
 import { Manifest } from "../manifest.ts";
+import { path } from "../deps.ts";
 
 Deno.test("basic test", async () => {
   const tasksDone: { [key: string]: boolean } = {};
@@ -136,4 +138,61 @@ Deno.test("async file deps test", async () => {
 
   assertEquals(tasksDone["taskA"], true);
   assertEquals(tasksDone["taskB"], true);
+});
+
+
+
+Deno.test("tasks with target and clean", async () => {
+
+  const tempDir = await Deno.makeTempDir();
+
+  console.log('tempDir', tempDir)
+
+  const exampleTarget1 = trackFile({
+    path: path.join(tempDir, 'exampleTarget1.txt'),
+  });
+  const testTask1 = task({
+    name: 'testTask1',
+    description: 'Test task to generate (and allow clean) of an example target',
+    action: async () => {
+      await Deno.writeTextFile(exampleTarget1.path, 'example contents');
+    },
+    targets: [exampleTarget1],
+  });
+
+  const exampleTarget2 = trackFile({
+    path: path.join(tempDir, 'exampleTarget2.txt'),
+  });
+  const testTask2 = task({
+    name: 'testTask2',
+    description: 'Test task to generate (and allow clean) of an example target',
+    action: async () => {
+      await Deno.writeTextFile(exampleTarget2.path, 'example contents');
+    },
+    targets: [exampleTarget2],
+  });
+
+  // precheck nonexists
+  assertEquals(await exampleTarget1.exists(), false);
+  assertEquals(await exampleTarget2.exists(), false);
+
+  // setup exec ctx
+  const ctx = await execBasic([], [testTask1, testTask2], new Manifest(""));
+
+  // run test tasks
+  await ctx.getTaskByName("testTask1")?.exec(ctx);
+  assertEquals(await exampleTarget1.exists(), true);
+
+  await ctx.getTaskByName("testTask2")?.exec(ctx);
+  assertEquals(await exampleTarget2.exists(), true);
+
+  // clean
+  await ctx.getTaskByName("clean")?.exec(ctx);
+
+  // check nonexists
+  assertEquals(await exampleTarget1.exists(), false);
+  assertEquals(await exampleTarget2.exists(), false);
+
+  // clean tempdir
+  await Deno.remove(tempDir, { recursive: true });
 });


### PR DESCRIPTION
Adds the ability to reset the last execution
- Task by task
- Whole manifest

Ex: 

- **dnit clean**
- **dnit clean build_javaserver yarn_client**