### PR TITLE
Move 'list' and 'tabcompletion' to builtin tasks

### DIFF
--- a/dnit.ts
+++ b/dnit.ts
@@ -661,31 +661,52 @@ export type ExecResult = {
   success: boolean;
 };
 
-// Builtin task 'clean'
-const clean = task({
-  name: "clean",
-  description: "Clean tracked files",
-  action: async (ctx: TaskContext) => {
-    const positionalArgs = ctx.args["_"];
+const builtinTasks = [
+  task({
+    name: "clean",
+    description: "Clean tracked files",
+    action: async (ctx: TaskContext) => {
+      const positionalArgs = ctx.args["_"];
 
-    const affectedTasks: Task[] = positionalArgs.length > 1
-      ? positionalArgs.map((arg) => ctx.exec.taskRegister.get(String(arg)))
-        .filter((task) => task !== undefined) as Task[]
-      : Array.from(ctx.exec.taskRegister.values());
-    if (affectedTasks.length > 0) {
-      console.log("Clean tasks:");
-      /// Reset tasks
-      await Promise.all(
-        affectedTasks.map((t) => {
-          console.log(`  ${t.name}`);
-          ctx.exec.asyncQueue.schedule(() => t.reset(ctx.exec));
-        }),
-      );
-      // await ctx.exec.manifest.save();
-    }
-  },
-  uptodate: runAlways,
-});
+      const affectedTasks: Task[] = positionalArgs.length > 1
+        ? positionalArgs.map((arg) => ctx.exec.taskRegister.get(String(arg)))
+          .filter((task) => task !== undefined) as Task[]
+        : Array.from(ctx.exec.taskRegister.values());
+      if (affectedTasks.length > 0) {
+        console.log("Clean tasks:");
+        /// Reset tasks
+        await Promise.all(
+          affectedTasks.map((t) => {
+            console.log(`  ${t.name}`);
+            ctx.exec.asyncQueue.schedule(() => t.reset(ctx.exec));
+          }),
+        );
+        // await ctx.exec.manifest.save();
+      }
+    },
+    uptodate: runAlways,
+  }),
+
+  task({
+    name: 'list',
+    description: 'List tasks',
+    action: (ctx: TaskContext) => {
+      showTaskList(ctx.exec, ctx.args);
+    },
+    uptodate: runAlways,
+  }),
+
+  task({
+    name: 'tabcompletion',
+    description: 'Generate shell completion script',
+    action: () => {
+      // todo: detect shell type and generate appropriate script
+      // or add args for shell type
+      echoBashCompletionScript();
+    },
+    uptodate: runAlways,
+  }),
+];
 
 /** Execute given commandline args and array of items (task & trackedfile) */
 export async function execCli(
@@ -706,7 +727,9 @@ export async function execCli(
   tasks.forEach((t) => ctx.taskRegister.set(t.name, t));
 
   /// register built-in tasks:
-  ctx.taskRegister.set(clean.name, clean);
+  for(const t of builtinTasks) {
+    ctx.taskRegister.set(t.name, t);
+  }
 
   let requestedTaskName: string | null = null;
   const positionalArgs = args["_"];
@@ -715,19 +738,7 @@ export async function execCli(
   }
 
   if (requestedTaskName === null) {
-    ctx.taskLogger.error("No task name given");
-    showTaskList(ctx, args);
-    return { success: false };
-  }
-
-  if (requestedTaskName === "list") {
-    showTaskList(ctx, args);
-    return { success: true };
-  }
-
-  if (requestedTaskName === "tabcompletion") {
-    echoBashCompletionScript();
-    return { success: true };
+    requestedTaskName = "list";
   }
 
   try {
@@ -771,7 +782,9 @@ export async function execBasic(
   tasks.forEach((t) => ctx.taskRegister.set(t.name, t));
 
   /// register built-in tasks:
-  ctx.taskRegister.set(clean.name, clean);
+  for(const t of builtinTasks) {
+    ctx.taskRegister.set(t.name, t);
+  }
 
   await Promise.all(
     Array.from(ctx.taskRegister.values()).map((t) =>

--- a/dnit.ts
+++ b/dnit.ts
@@ -277,9 +277,12 @@ export class Task {
     if (actualUpToDate) {
       ctx.taskLogger.info(`--- ${this.name}`);
     } else {
-      ctx.taskLogger.info(`{-- ${this.name}`);
+
+      // suppress logging the task "{-- name --}" for the list task
+      const logTaskScope = (this.name !== 'list');
+      if (logTaskScope) { ctx.taskLogger.info(`{-- ${this.name}`); }
       await this.action(taskContext(ctx, this));
-      ctx.taskLogger.info(`--} ${this.name}`);
+      if (logTaskScope) { ctx.taskLogger.info(`--} ${this.name}`); }
 
       {
         /// recalc & save data of deps:


### PR DESCRIPTION
With this update there are no longer any directly hardcoded arguments/actions, instead they are added as builtin tasks.

So far: clean, list, tabcompletion

It has benefits:
* Unit tests can run them (as was the case in PR #11) - because the unit tests use a simpler 'execBasic' rather than the full 'execCli'
* They appear in the `list` output
* Less special behaviour

PR #11 already put 'clean' in using 'builtin' task method.  This PR concludes that approach by moving 'list' and 'tabcompletion' into the same and makes builtin tasks a list.

